### PR TITLE
Stop storing conflicted replica on single node

### DIFF
--- a/justin-core/src/main/scala/justin/db/ReplicaLocalReader.scala
+++ b/justin-core/src/main/scala/justin/db/ReplicaLocalReader.scala
@@ -12,9 +12,8 @@ class ReplicaLocalReader(storage: GetStorageProtocol)(implicit ec: ExecutionCont
 
   def apply(id: UUID, resolveDataOriginality: ResolveDataOriginality): Future[StorageNodeReadingResult] = {
     storage.get(id)(resolveDataOriginality).map {
-      case StorageGetData.Single(data)             => StorageNodeReadingResult.Found(data)
-      case StorageGetData.None                     => StorageNodeReadingResult.NotFound
-      case StorageGetData.Conflicted(data1, data2) => StorageNodeReadingResult.Conflicted(data1, data2)
-    } recover { case _                             => StorageNodeReadingResult.FailedRead }
+      case StorageGetData.Single(data) => StorageNodeReadingResult.Found(data)
+      case StorageGetData.None         => StorageNodeReadingResult.NotFound
+    } recover { case _                 => StorageNodeReadingResult.FailedRead }
   }
 }

--- a/justin-core/src/main/scala/justin/db/ReplicaLocalWriter.scala
+++ b/justin-core/src/main/scala/justin/db/ReplicaLocalWriter.scala
@@ -3,51 +3,29 @@ package justin.db
 import justin.db.StorageNodeActorProtocol._
 import justin.db.storage.PluggableStorageProtocol.{StorageGetData, StoragePutData}
 import justin.db.storage.{GetStorageProtocol, PutStorageProtocol}
+import justin.db.versioning.VectorClockComparator
 import justin.db.versioning.VectorClockComparator.VectorClockRelation
-import justin.db.versioning.VectorClockComparator.VectorClockRelation._
-import justin.db.versioning.{NodeIdVectorClock, VCs2Compare, VectorClockComparator}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class ReplicaLocalWriter(storage: GetStorageProtocol with PutStorageProtocol)(implicit ec: ExecutionContext) {
 
-  def apply(data: Data, resolveDataOriginality: ResolveDataOriginality): Future[StorageNodeWritingResult] = {
-    storage.get(data.id)(resolveDataOriginality).flatMap {
-      case StorageGetData.None                   => putSingleSuccessfulWrite(data, resolveDataOriginality)
-      case conflicted: StorageGetData.Conflicted => handleExistedConflictData(data, conflicted, resolveDataOriginality)
-      case single: StorageGetData.Single         => handleExistedSingleData(data, single, resolveDataOriginality)
-    } recover {
-      case _                                     => StorageNodeWritingResult.FailedWrite
-    }
+  def apply(newData: Data, resolveDataOriginality: ResolveDataOriginality): Future[StorageNodeWritingResult] = {
+    storage.get(newData.id)(resolveDataOriginality).flatMap {
+      case StorageGetData.None            => putSingleSuccessfulWrite(newData, resolveDataOriginality)
+      case StorageGetData.Single(oldData) => handleExistedSingleData(oldData, newData, resolveDataOriginality)
+    } recover { case _                    => StorageNodeWritingResult.FailedWrite }
   }
 
-  private def handleExistedConflictData(data: Data, conflicted: StorageGetData.Conflicted, resolveDataOriginality: ResolveDataOriginality) = {
-    val vcCmpRes  = compareVectorClocks(conflicted.data1.vclock, data.vclock)
-    val vcCmpRes2 = compareVectorClocks(conflicted.data2.vclock, data.vclock)
-
-    (vcCmpRes, vcCmpRes2) match {
-      case (Consequent, Consequent) => putSingleSuccessfulWrite(data, resolveDataOriginality)
-      case _                        => Future.successful(StorageNodeWritingResult.FailedWrite)
-    }
-  }
-
-  private def handleExistedSingleData(data: Data, single: StorageGetData.Single, resolveDataOriginality: ResolveDataOriginality) = {
-    compareVectorClocks(single.data.vclock, data.vclock) match {
+  private def handleExistedSingleData(oldData: Data, newData: Data, resolveDataOriginality: ResolveDataOriginality) = {
+    new VectorClockComparator().apply(oldData.vclock, newData.vclock) match {
       case VectorClockRelation.Predecessor => Future.successful(StorageNodeWritingResult.FailedWrite)
-      case VectorClockRelation.Conflict    => putConflictSuccessfulWrite(StoragePutData.Conflict(single.data.id, single.data, data), resolveDataOriginality)
-      case VectorClockRelation.Consequent  => putSingleSuccessfulWrite(data, resolveDataOriginality)
+      case VectorClockRelation.Conflict    => Future.successful(StorageNodeWritingResult.ConflictedWrite(oldData, newData))
+      case VectorClockRelation.Consequent  => putSingleSuccessfulWrite(newData, resolveDataOriginality)
     }
   }
 
-  private def putSingleSuccessfulWrite(data: Data, resolveDataOriginality: ResolveDataOriginality) = {
-    storage.put(StoragePutData.Single(data))(resolveDataOriginality).map(_ => StorageNodeWritingResult.SuccessfulWrite)
-  }
-
-  private def putConflictSuccessfulWrite(conflict: StoragePutData.Conflict, resolveDataOriginality: ResolveDataOriginality) = {
-    storage.put(conflict)(resolveDataOriginality).map(_ => StorageNodeWritingResult.ConflictedWrite)
-  }
-
-  private def compareVectorClocks(vclock: NodeIdVectorClock, vclock2: NodeIdVectorClock) = {
-    new VectorClockComparator().apply(VCs2Compare(vclock, vclock2))
+  private def putSingleSuccessfulWrite(newData: Data, resolveDataOriginality: ResolveDataOriginality) = {
+    storage.put(StoragePutData(newData))(resolveDataOriginality).map(_ => StorageNodeWritingResult.SuccessfulWrite)
   }
 }

--- a/justin-core/src/main/scala/justin/db/StorageNodeActorProtocol.scala
+++ b/justin-core/src/main/scala/justin/db/StorageNodeActorProtocol.scala
@@ -16,10 +16,9 @@ object StorageNodeActorProtocol {
 
   sealed trait StorageNodeReadingResult
   object StorageNodeReadingResult {
-    case class Found(d: Data)                       extends StorageNodeReadingResult
-    case object NotFound                            extends StorageNodeReadingResult
-    case object FailedRead                          extends StorageNodeReadingResult
-    case class Conflicted(data1: Data, data2: Data) extends StorageNodeReadingResult
+    case class Found(d: Data) extends StorageNodeReadingResult
+    case object NotFound      extends StorageNodeReadingResult
+    case object FailedRead    extends StorageNodeReadingResult
   }
 
   // write part
@@ -31,9 +30,9 @@ object StorageNodeActorProtocol {
 
   sealed trait StorageNodeWritingResult
   object StorageNodeWritingResult {
-    case object SuccessfulWrite extends StorageNodeWritingResult
-    case object FailedWrite     extends StorageNodeWritingResult
-    case object ConflictedWrite extends StorageNodeWritingResult
+    case object SuccessfulWrite                              extends StorageNodeWritingResult
+    case object FailedWrite                                  extends StorageNodeWritingResult
+    case class ConflictedWrite(oldData: Data, newData: Data) extends StorageNodeWritingResult
   }
 
   // cluster part

--- a/justin-core/src/main/scala/justin/db/client/ActorRefStorageNodeClient.scala
+++ b/justin-core/src/main/scala/justin/db/client/ActorRefStorageNodeClient.scala
@@ -19,20 +19,19 @@ class ActorRefStorageNodeClient(private val storageNodeActor: StorageNodeActorRe
     lazy val errorMsg = s"[HttpStorageNodeClient] Couldn't read value with id ${id.toString}"
 
     (storageNodeActor.storageNodeActor ? StorageNodeReadData.Replicated(r, id)).mapTo[StorageNodeReadingResult].map {
-      case StorageNodeReadingResult.Found(data)              => GetValueResponse.Found(data)
-      case StorageNodeReadingResult.NotFound                 => GetValueResponse.NotFound
-      case StorageNodeReadingResult.FailedRead               => GetValueResponse.Failure(errorMsg)
-      case StorageNodeReadingResult.Conflicted(data1, data2) => GetValueResponse.Conflicted(data1, data2)
-    }.recover { case _                                       => GetValueResponse.Failure(errorMsg) }
+      case StorageNodeReadingResult.Found(data) => GetValueResponse.Found(data)
+      case StorageNodeReadingResult.NotFound    => GetValueResponse.NotFound
+      case StorageNodeReadingResult.FailedRead  => GetValueResponse.Failure(errorMsg)
+    }.recover { case _                          => GetValueResponse.Failure(errorMsg) }
   }
 
   override def write(data: Data, w: W): Future[WriteValueResponse] = {
     lazy val errorMsg = s"[HttpStorageNodeClient] Couldn't write data: $data"
 
     (storageNodeActor.storageNodeActor ? StorageNodeWriteData.Replicate(w, data)).mapTo[StorageNodeWritingResult].map {
-      case StorageNodeWritingResult.SuccessfulWrite => WriteValueResponse.Success
-      case StorageNodeWritingResult.ConflictedWrite => WriteValueResponse.Conflict
-      case StorageNodeWritingResult.FailedWrite     => WriteValueResponse.Failure(errorMsg)
-    }.recover { case _                              => WriteValueResponse.Failure(errorMsg) }
+      case StorageNodeWritingResult.SuccessfulWrite       => WriteValueResponse.Success
+      case StorageNodeWritingResult.ConflictedWrite(_, _) => WriteValueResponse.Conflict
+      case StorageNodeWritingResult.FailedWrite           => WriteValueResponse.Failure(errorMsg)
+    }.recover { case _                                    => WriteValueResponse.Failure(errorMsg) }
   }
 }

--- a/justin-core/src/main/scala/justin/db/client/StorageNodeClient.scala
+++ b/justin-core/src/main/scala/justin/db/client/StorageNodeClient.scala
@@ -17,7 +17,6 @@ object GetValueResponse {
   case class Found(data: Data)                    extends GetValueResponse
   case object NotFound                            extends GetValueResponse
   case class Failure(error: String)               extends GetValueResponse
-  case class Conflicted(data1: Data, data2: Data) extends GetValueResponse
 }
 
 sealed trait WriteValueResponse

--- a/justin-core/src/main/scala/justin/db/storage/PluggableStorageProtocol.scala
+++ b/justin-core/src/main/scala/justin/db/storage/PluggableStorageProtocol.scala
@@ -22,16 +22,11 @@ object PluggableStorageProtocol {
   
   sealed trait StorageGetData
   object StorageGetData {
-    case class Single(data: Data)                   extends StorageGetData
-    case class Conflicted(data1: Data, data2: Data) extends StorageGetData
-    case object None                                extends StorageGetData
+    case class Single(data: Data) extends StorageGetData
+    case object None              extends StorageGetData
   }
 
-  sealed trait StoragePutData
-  object StoragePutData {
-    case class Single(data: Data)                           extends StoragePutData
-    case class Conflict(id: UUID, data1: Data, data2: Data) extends StoragePutData
-  }
+  case class StoragePutData(data: Data) extends AnyVal
 
   sealed trait Ack
   case object Ack extends Ack {

--- a/justin-core/src/test/scala/justin/db/ReachConsensusReplicatedWritesTest.scala
+++ b/justin-core/src/test/scala/justin/db/ReachConsensusReplicatedWritesTest.scala
@@ -22,8 +22,8 @@ class ReachConsensusReplicatedWritesTest extends FlatSpec with Matchers {
 
   it should "NOT reach consensus when number of successful write operation is smaller than desired" in {
     // given
-    val w = W(1)
-    val writes = List(ConflictedWrite)
+    val w = W(2)
+    val writes = List(FailedWrite, SuccessfulWrite)
 
     // when
     val result = ReachConsensusReplicatedWrites.apply(w)(writes)

--- a/justin-core/src/test/scala/justin/db/ReplicaLocalReaderTest.scala
+++ b/justin-core/src/test/scala/justin/db/ReplicaLocalReaderTest.scala
@@ -48,24 +48,6 @@ class ReplicaLocalReaderTest extends FlatSpec with Matchers with ScalaFutures {
     whenReady(result) { _ shouldBe StorageNodeReadingResult.NotFound }
   }
 
-  it should "found conflicted data for existing key" in {
-    // given
-    val id = UUID.randomUUID()
-    val data1 = Data(id, "some-data-1")
-    val data2 = Data(id, "some-data-2")
-    val service = new ReplicaLocalReader(new GetStorageProtocol {
-      override def get(id: UUID)(resolveOriginality: (UUID) => DataOriginality): Future[StorageGetData] = {
-        Future.successful(StorageGetData.Conflicted(data1, data2))
-      }
-    })
-
-    // when
-    val result = service.apply(id, null)
-
-    // then
-    whenReady(result) { _ shouldBe StorageNodeReadingResult.Conflicted(data1, data2) }
-  }
-
   it should "recover failure reading" in {
     // given
     val id = UUID.randomUUID()

--- a/justin-core/src/test/scala/justin/db/client/ActorRefStorageNodeClientTest.scala
+++ b/justin-core/src/test/scala/justin/db/client/ActorRefStorageNodeClientTest.scala
@@ -61,21 +61,6 @@ class ActorRefStorageNodeClientTest extends TestKit(ActorSystem("test-system"))
     whenReady(result) { _ shouldBe GetValueResponse.Failure(s"[HttpStorageNodeClient] Couldn't read value with id ${id.toString}") }
   }
 
-  it should "handle actor's \"Conflicted\" message for asked data" in {
-    // given
-    val id       = UUID.randomUUID()
-    val data1    = Data(id, "value-1")
-    val data2    = Data(id, "value-2")
-    val actorRef = getTestActorRef(msgBack = StorageNodeReadingResult.Conflicted(data1, data2))
-    val client   = new ActorRefStorageNodeClient(StorageNodeActorRef(actorRef))(system.dispatcher)
-
-    // when
-    val result = client.get(id, R(1))
-
-    // then
-    whenReady(result) { _ shouldBe GetValueResponse.Conflicted(data1, data2) }
-  }
-
   it should "recover actor's reading behavior" in {
     // given
     val id       = UUID.randomUUID()
@@ -138,7 +123,7 @@ class ActorRefStorageNodeClientTest extends TestKit(ActorSystem("test-system"))
     // given
     val id       = UUID.randomUUID()
     val data     = Data(id, "value")
-    val actorRef = writeTestActorRef(msgBack = StorageNodeWritingResult.ConflictedWrite)
+    val actorRef = writeTestActorRef(msgBack = StorageNodeWritingResult.ConflictedWrite(data, data))
     val client   = new ActorRefStorageNodeClient(StorageNodeActorRef(actorRef))(system.dispatcher)
 
     // when

--- a/justin-core/src/test/scala/justin/db/versioning/VectorClockComparatorTest.scala
+++ b/justin-core/src/test/scala/justin/db/versioning/VectorClockComparatorTest.scala
@@ -16,45 +16,39 @@ class VectorClockComparatorTest extends FlatSpec with Matchers {
     * -------------------
     */
   it should "pass conflict scenario nr 1" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:1, B:1",
-      potentiallyConsequentVC = "A:1, C:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Conflict
+    val baseVC     = "A:1, B:1"
+    val comparedVC = "A:1, C:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Conflict
   }
 
   it should "pass conflict scenario nr 2" in {
-    val vcs4 = VCs2Compare(
-      baseVC                  = "A:2",
-      potentiallyConsequentVC = "A:1, B:1"
-    )
-    comparator.apply(vcs4) shouldBe VectorClockRelation.Conflict
+    val baseVC     = "A:2"
+    val comparedVC = "A:1, B:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Conflict
   }
 
   it should "pass conflict scenario nr 3" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:1",
-      potentiallyConsequentVC = "B:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Conflict
+    val baseVC     = "A:1"
+    val comparedVC = "B:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Conflict
   }
 
   it should "pass conflict scenario nr 4" in {
-    val vcs = VCs2Compare(
-        baseVC                  = "A:1, B:1, C:2",
-        potentiallyConsequentVC = "A:1, B:2, C:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Conflict
+    val baseVC     = "A:1, B:1, C:2"
+    val comparedVC = "A:1, B:2, C:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Conflict
   }
 
   it should "pass conflict scenario nr 5" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:1, B:2",
-      potentiallyConsequentVC = "A:1, B:1, C:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Conflict
-  }
+    val baseVC     = "A:1, B:2"
+    val comparedVC = "A:1, B:1, C:1"
 
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Conflict
+  }
 
   /**
     * ----------------------
@@ -62,27 +56,24 @@ class VectorClockComparatorTest extends FlatSpec with Matchers {
     * ----------------------
     */
   it should "pass predecessor scenario nr 1" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:2, B:1",
-      potentiallyConsequentVC = "A:1, B:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Predecessor
+    val baseVC     = "A:2, B:1"
+    val comparedVC = "A:1, B:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Predecessor
   }
 
   it should "pass predecessor scenario nr 2" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:2",
-      potentiallyConsequentVC = "A:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Predecessor
+    val baseVC     = "A:2"
+    val comparedVC = "A:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Predecessor
   }
 
   it should "pass predecessor scenario nr 3" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:1, B:1",
-      potentiallyConsequentVC = "A:1, B:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Predecessor
+    val baseVC     = "A:1, B:1"
+    val comparedVC = "A:1, B:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Predecessor
   }
 
   /**
@@ -91,26 +82,23 @@ class VectorClockComparatorTest extends FlatSpec with Matchers {
     * ----------------------
     */
   it should "pass consequent scenario nr 1" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:1",
-      potentiallyConsequentVC = "A:2"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Consequent
+    val baseVC     = "A:1"
+    val comparedVC = "A:2"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Consequent
   }
 
   it should "pass consequent scenario nr 2" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:1, B:1",
-      potentiallyConsequentVC = "A:1, B:1, C:1"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Consequent
+    val baseVC     = "A:1, B:1"
+    val comparedVC = "A:1, B:1, C:1"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Consequent
   }
 
   it should "pass consequent scenario nr 3" in {
-    val vcs = VCs2Compare(
-      baseVC                  = "A:1, B:1, C:2",
-      potentiallyConsequentVC = "A:1, B:1, C:3"
-    )
-    comparator.apply(vcs) shouldBe VectorClockRelation.Consequent
+    val baseVC     = "A:1, B:1, C:2"
+    val comparedVC = "A:1, B:1, C:3"
+
+    comparator.apply(baseVC, comparedVC) shouldBe VectorClockRelation.Consequent
   }
 }

--- a/justin-http-client/src/main/scala/justin/http_client/HttpRouter.scala
+++ b/justin-http-client/src/main/scala/justin/http_client/HttpRouter.scala
@@ -36,7 +36,6 @@ class HttpRouter(client: ActorRefStorageNodeClient)(implicit ec: ExecutionContex
       (get & path("get") & pathEndOrSingleSlash & parameters('id.as(UUIDUnmarshaller), 'r.as[Int])) { (uuid, r) =>
         onComplete(client.get(uuid, R(r))) {
           case Success(GetValueResponse.Found(data))              => respondWithHeader(VectorClockHeader(data.vclock)) { complete(OK -> Result(data.value)) }
-          case Success(GetValueResponse.Conflicted(data1, data2)) => respondWithHeader(VectorClockHeader(data1.vclock)) { complete(MultipleChoices -> Result("Multiple Choices")) } // TODO: how returned vector clock header and result should look like
           case Success(GetValueResponse.NotFound)                 => complete(NotFound -> Result(s"Not found value with id ${uuid.toString}"))
           case Success(GetValueResponse.Failure(err))             => complete(BadRequest -> Result(err))
           case Failure(ex)                                        => complete(InternalServerError -> Result(ex.getMessage))

--- a/justin-http-client/src/test/resources/test.conf
+++ b/justin-http-client/src/test/resources/test.conf
@@ -1,7 +1,4 @@
 akka {
-  loglevel = DEBUG
-
-  actor {
-    provider = local
-  }
+  stdout-loglevel = "OFF"
+  loglevel = "OFF"
 }

--- a/justin-http-client/src/test/scala/justin/http_client/HttpRouterTest.scala
+++ b/justin-http-client/src/test/scala/justin/http_client/HttpRouterTest.scala
@@ -35,20 +35,6 @@ class HttpRouterTest extends FlatSpec with Matchers with ScalatestRouteTest {
     }
   }
 
-  it should "get \"MultipleChoices\" http code for read conflicted data" in {
-    val r      = 1
-    val id     = UUID.randomUUID()
-    val data1  = Data(id, "value-1")
-    val data2  = Data(id, "value-2")
-    val router = new HttpRouter(getConflicted(data1, data2))
-
-    Get(s"/get?id=${id.toString}&r=$r") ~> Route.seal(router.routes) ~> check {
-      status                       shouldBe StatusCodes.MultipleChoices
-      responseAs[String].parseJson shouldBe JsObject("value" -> JsString("Multiple Choices"))
-      header[VectorClockHeader]    shouldBe Some(VectorClockHeader(data1.vclock)) // TODO: this is not yet true
-    }
-  }
-
   it should "get \"NotFound\" http code for missed searched data" in {
     val value  = "value"
     val id     = UUID.randomUUID().toString
@@ -92,10 +78,6 @@ class HttpRouterTest extends FlatSpec with Matchers with ScalatestRouteTest {
 
   private def getFound(data: Data) = new ActorRefStorageNodeClient(StorageNodeActorRef(null)) {
     override def get(id: UUID, r: R): Future[GetValueResponse] = Future.successful(GetValueResponse.Found(data))
-  }
-
-  private def getConflicted(data1: Data, data2: Data) = new ActorRefStorageNodeClient(StorageNodeActorRef(null)) {
-    override def get(id: UUID, r: R): Future[GetValueResponse] = Future.successful(GetValueResponse.Conflicted(data1, data2))
   }
 
   private def notFound(value: String) = new ActorRefStorageNodeClient(StorageNodeActorRef(null)) {

--- a/justin-storage-in-mem/src/main/scala/justin/db/storage/InMemStorage.scala
+++ b/justin-storage-in-mem/src/main/scala/justin/db/storage/InMemStorage.scala
@@ -14,18 +14,15 @@ import scala.concurrent.{ExecutionContext, Future}
 class InMemStorage(implicit ec: ExecutionContext) extends PluggableStorageProtocol {
   import scala.collection.mutable
 
-  private case class MapVal(data1: Data, data2: Option[Data])
-
-  private type MMap           = mutable.Map[RingPartitionId, Map[UUID, MapVal]]
-  private var primaries: MMap = mutable.Map.empty[RingPartitionId, Map[UUID, MapVal]]
-  private var replicas: MMap  = mutable.Map.empty[RingPartitionId, Map[UUID, MapVal]]
+  private type MMap           = mutable.Map[RingPartitionId, Map[UUID, Data]]
+  private var primaries: MMap = mutable.Map.empty[RingPartitionId, Map[UUID, Data]]
+  private var replicas: MMap  = mutable.Map.empty[RingPartitionId, Map[UUID, Data]]
 
   override def get(id: UUID)(resolveOriginality: (UUID) => DataOriginality): Future[StorageGetData] = Future.successful {
     def get(mmap: MMap, partitionId: RingPartitionId) = {
       mmap.get(partitionId).fold[StorageGetData](StorageGetData.None) { _.get(id) match {
-        case None                             => StorageGetData.None
-        case Some(MapVal(data1, Some(data2))) => StorageGetData.Conflicted(data1, data2)
-        case Some(MapVal(data1, None))        => StorageGetData.Single(data1)
+        case Some(data) => StorageGetData.Single(data)
+        case None       => StorageGetData.None
       }}
     }
 
@@ -35,22 +32,17 @@ class InMemStorage(implicit ec: ExecutionContext) extends PluggableStorageProtoc
     }
   }
 
-  override def put(cmd: StoragePutData)(resolveOriginality: (UUID) => DataOriginality): Future[Ack] = {
-    def update(mmap: MMap, partitionId: RingPartitionId, id: UUID, mapVal: MapVal) = {
+  override def put(putData: StoragePutData)(resolveOriginality: (UUID) => DataOriginality): Future[Ack] = {
+    def update(mmap: MMap, partitionId: RingPartitionId, data: Data) = {
       mmap.get(partitionId) match {
-        case Some(partitionMap) => mmap + (partitionId -> (partitionMap ++ Map(id -> mapVal)))
-        case None               => mmap + (partitionId -> Map(id -> mapVal))
+        case Some(partitionMap) => mmap + (partitionId -> (partitionMap ++ Map(data.id -> data)))
+        case None               => mmap + (partitionId -> Map(data.id -> data))
       }
     }
 
-    val (id, mapVal) = cmd match {
-      case StoragePutData.Single(data)                => (data.id, MapVal(data, None))
-      case StoragePutData.Conflict(uid, data1, data2) => (uid, MapVal(data1, Option(data2)))
-    }
-
-    resolveOriginality(id) match {
-      case DataOriginality.Primary(partitionId) => primaries = update(primaries, partitionId, id, mapVal)
-      case DataOriginality.Replica(partitionId) => replicas  = update(replicas, partitionId, id, mapVal)
+    resolveOriginality(putData.data.id) match {
+      case DataOriginality.Primary(partitionId) => primaries = update(primaries, partitionId, putData.data)
+      case DataOriginality.Replica(partitionId) => replicas  = update(replicas, partitionId, putData.data)
     }
 
     Ack.future

--- a/justin-storage-in-mem/src/test/scala/justin/db/storage/InMemStorageTest.scala
+++ b/justin-storage-in-mem/src/test/scala/justin/db/storage/InMemStorageTest.scala
@@ -17,23 +17,9 @@ class InMemStorageTest extends FlatSpec with Matchers {
 
   it should "store single data" in {
     // given
-    val data = StoragePutData.Single(Data(id = UUID.randomUUID(), "some-data"))
+    val data         = StoragePutData(Data(id = UUID.randomUUID(), "some-data"))
     val inMemStorage = new InMemStorage
-    val resolver = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
-
-    // when
-    val result = Await.result(inMemStorage.put(data)(resolver), atMost = 5 seconds)
-
-    // then
-    result shouldBe Ack
-  }
-
-  it should "store conflicted data" in {
-    // given
-    val id = UUID.randomUUID()
-    val data = StoragePutData.Conflict(id, Data(id, "some-data-1"), Data(id, "some-data-2"))
-    val inMemStorage = new InMemStorage
-    val resolver = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
+    val resolver     = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
 
     // when
     val result = Await.result(inMemStorage.put(data)(resolver), atMost = 5 seconds)
@@ -44,9 +30,9 @@ class InMemStorageTest extends FlatSpec with Matchers {
 
   it should "get single data for appropriate identifier" in {
     // given
-    val data = StoragePutData.Single(Data(id = UUID.randomUUID(), "some-data"))
+    val data         = StoragePutData(Data(id = UUID.randomUUID(), "some-data"))
     val inMemStorage = new InMemStorage
-    val resolver = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
+    val resolver     = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
     Await.result(inMemStorage.put(data)(resolver), atMost = 5 seconds)
 
     // when
@@ -60,8 +46,8 @@ class InMemStorageTest extends FlatSpec with Matchers {
     // given
     val noExistingId = UUID.randomUUID()
     val inMemStorage = new InMemStorage
-    val resolver  = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
-    val otherData = StoragePutData.Single(Data(id = UUID.randomUUID(), "some-data"))
+    val resolver     = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
+    val otherData    = StoragePutData(Data(id = UUID.randomUUID(), "some-data"))
     Await.result(inMemStorage.put(otherData)(resolver), atMost = 5 seconds)
 
     // when
@@ -73,10 +59,10 @@ class InMemStorageTest extends FlatSpec with Matchers {
 
   it should "get none data for not existing partitionId" in {
     // given
-    val uid = UUID.randomUUID()
+    val uid                       = UUID.randomUUID()
     val noExistingRingPartitionId = 1
-    val inMemStorage = new InMemStorage
-    val resolver = (id: UUID) => DataOriginality.Replica(ringPartitionId = noExistingRingPartitionId)
+    val inMemStorage              = new InMemStorage
+    val resolver                  = (id: UUID) => DataOriginality.Replica(ringPartitionId = noExistingRingPartitionId)
 
     // when
     val result = Await.result(inMemStorage.get(uid)(resolver), atMost = 5 seconds)
@@ -85,43 +71,13 @@ class InMemStorageTest extends FlatSpec with Matchers {
     result shouldBe StorageGetData.None
   }
 
-  it should "get conflicted data for appropriate identifier" in {
-    // given
-    val id = UUID.randomUUID()
-    val data = StoragePutData.Conflict(id, Data(id, "some-data-1"), Data(id, "some-data-2"))
-    val inMemStorage = new InMemStorage
-    val resolver = (id: UUID) => DataOriginality.Primary(ringPartitionId = 1)
-    Await.result(inMemStorage.put(data)(resolver), atMost = 5 seconds)
-
-    // when
-    val result = Await.result(inMemStorage.get(id)(resolver), atMost = 5 seconds)
-
-    // then
-    result shouldBe StorageGetData.Conflicted(data.data1, data.data2)
-  }
-
-  it should "store and read replicated data" in {
-    // given
-    val id = UUID.randomUUID()
-    val data = StoragePutData.Conflict(id, Data(id, "some-data-1"), Data(id, "some-data-2"))
-    val inMemStorage = new InMemStorage
-    val resolver = (id: UUID) => DataOriginality.Replica(ringPartitionId = 1)
-
-    // when
-    Await.result(inMemStorage.put(data)(resolver), atMost = 5 seconds)
-    val result = Await.result(inMemStorage.get(id)(resolver), atMost = 5 seconds)
-
-    // then
-    result shouldBe StorageGetData.Conflicted(data.data1, data.data2)
-  }
-
   it should "store and merge many data within under single partitionId" in {
     // given
-    val id1 = UUID.randomUUID()
-    val id2 = UUID.randomUUID()
-    val data1 = StoragePutData.Single(Data(id1, "some-data"))
-    val data2 = StoragePutData.Single(Data(id2, "some-data"))
-    val resolver = (id: UUID) => DataOriginality.Replica(ringPartitionId = 1)
+    val id1          = UUID.randomUUID()
+    val id2          = UUID.randomUUID()
+    val data1        = StoragePutData(Data(id1, "some-data"))
+    val data2        = StoragePutData(Data(id2, "some-data"))
+    val resolver     = (id: UUID) => DataOriginality.Replica(ringPartitionId = 1)
     val inMemStorage = new InMemStorage
 
     Await.result(inMemStorage.put(data1)(resolver), atMost = 5 seconds)


### PR DESCRIPTION
Goal of this PR is simplification of dealing with conflicted replicas.
These are going to be resolved while reading using Read Repair technique or (if its not possible) doing manually by client of JustinDB.
In next PR we should expect implementation of Read Repair.